### PR TITLE
Update list of allowable materials and default thicknesses.

### DIFF
--- a/cabwiz/cabinet.py
+++ b/cabwiz/cabinet.py
@@ -64,13 +64,19 @@ max_cabinet_width = 36
 # due to the hinges.
 door_hinge_gap = 0.125
 
-# Primary materials list. Does each material have a standard thickness
-# associated with it?
-
-materials = ( 'Plywood'
+# List of materials, in the order we want them to appear in the selection list.
+materials = [ 'Standard Plywood'
+            , 'Marine-Grade Plywood'
             , 'Melamine'
-            , 'Graphite'
-            , 'Steel' )
+            ]
+
+# Dictionary of materials with default thickness for each in inches.
+# Note: these thicknesses must still be changeable to something else, as lots do
+# vary in thickness. For example, gray melamine lots are often 0.74" thick.
+matl_thicknesses = { 'Standard Plywood': 0.74
+                   , 'Marine-Grade Plywood': 0.75
+                   , 'Melamine': 0.76
+                   }
 
 
 def cabinet_run(fullwidth, height, depth, num_fillers=0, material='Plywood',

--- a/cabwiz/cabinet.py
+++ b/cabwiz/cabinet.py
@@ -65,7 +65,7 @@ max_cabinet_width = 36
 door_hinge_gap = 0.125
 
 # List of materials, in the order we want them to appear in the selection list.
-materials = [ 'Standard Plywood'        # default choice in UI
+materials = [ 'Standard Plywood'        # default choice if none specified
             , 'Marine-Grade Plywood'
             , 'Melamine'
             ]
@@ -79,8 +79,9 @@ matl_thicknesses = { 'Standard Plywood': 0.74
                    }
 
 
-def cabinet_run(fullwidth, height, depth, num_fillers=0, material='Plywood',
-                matl_thickness=0.75, topnailer_depth=4, door_thickness=0.75,
+def cabinet_run(fullwidth, height, depth, num_fillers=0, material=materials[0],
+                matl_thickness=matl_thicknesses[materials[0]],
+                topnailer_depth=4, door_thickness=0.75,
                 doortop_space=0.5, doorside_space_l=0.125,
                 doorside_space_m=0.125, doorside_space_r=0.125):
     """Construct a (single) :class:`Run <Run>` of cabinets.
@@ -112,11 +113,13 @@ def cabinet_run(fullwidth, height, depth, num_fillers=0, material='Plywood',
 
 
 class Run:
-    """A single run of cabinets (lower or upper)."""
+    """A single run of cabinets."""
 
     def __init__(self, fullwidth, height, depth, num_fillers=0,
-                 material='Plywood', matl_thickness=0.75, topnailer_depth=4,
-                 door_thickness=0.75, doortop_space=0.5, doorside_space_l=0.125,
+                 material=materials[0],
+                 matl_thickness=matl_thicknesses[materials[0]],
+                 topnailer_depth=4, door_thickness=0.75,
+                 doortop_space=0.5, doorside_space_l=0.125,
                  doorside_space_m=0.125, doorside_space_r=0.125):
         self._fullwidth = fullwidth
         self._height = height

--- a/cabwiz/cabinet.py
+++ b/cabwiz/cabinet.py
@@ -65,7 +65,7 @@ max_cabinet_width = 36
 door_hinge_gap = 0.125
 
 # List of materials, in the order we want them to appear in the selection list.
-materials = [ 'Standard Plywood'
+materials = [ 'Standard Plywood'        # default choice in UI
             , 'Marine-Grade Plywood'
             , 'Melamine'
             ]

--- a/cabwiz/cabwiz.py
+++ b/cabwiz/cabwiz.py
@@ -63,7 +63,7 @@ def start_cli(args):
     # Create a cabinet Run object which does all the calculating.
     cab_run = cab.Run(args.fullwidth, args.height, args.depth,
                       num_fillers=args.fillers,
-                      matl_thickness=args.thick)
+                      material=args.matl, matl_thickness=args.thick)
     # Create a job object that holds the name, a single cabinet run object,
     # and an optional description for the job.
     if args.desc is not None:
@@ -122,12 +122,13 @@ def get_parser():
                         default='0')
     parser.add_argument("-m", "--matl",
                         help="primary building material name",
-                        type=str)
+                        type=str,
+                        default=cab.materials[0])
     parser.add_argument("-th", "--thick",
                         help="building material thickness",
                         metavar='TH',
                         type=float,
-                        default='0.75')
+                        default=cab.matl_thicknesses[cab.materials[0]])
     parser.add_argument("-c", "--cutlist",
                         help="generate a cutlist & save in FN.pdf",
                         metavar='FN',

--- a/cabwiz/gui.py
+++ b/cabwiz/gui.py
@@ -85,8 +85,8 @@ class Application(ttk.Frame):
         self.height.set('')
         self.depth.set('')
         self.num_fillers.set(0)
-        self.material.set('Plywood')
-        self.thickness.set('0.75')
+        self.material.set(cab.materials[0])
+        self.thickness.set(cab.matl_thicknesses[self.material.get()])
         self.diff_btm_thickness.set('no')
         self.bottom_thickness.set('')
         self.doors_per_cab.set(2)
@@ -193,17 +193,18 @@ class Application(ttk.Frame):
                                 column=4, row=0, sticky=W, padx=3, pady=2)
             ttk.Label(miscframe, text='Material:').grid(
                 column=0, row=1, sticky=W, padx=(0, 2), pady=2)
-            material_cbx = ttk.Combobox(miscframe, textvariable=self.material,
-                                width=max(map(len, cab.materials)) + 2)
-            material_cbx['values'] = cab.materials
+            self.material_cbx = ttk.Combobox(
+                miscframe, textvariable=self.material,
+                width=max(map(len, cab.materials)) + 2
+            )
+            self.material_cbx['values'] = cab.materials
             # Prevent direct editing of the value in the combobox:
-            material_cbx.state(['readonly'])
+            self.material_cbx.state(['readonly'])
             # Call the `selection clear' method when the value changes. It looks
             # a bit odd visually without doing that.
-            material_cbx.bind('<<ComboboxSelected>>',
-                              lambda x: material_cbx.selection_clear())
-            material_cbx.grid(column=1, columnspan=2, row=1, sticky=W,
-                              padx=(6, 0), pady=2)
+            self.material_cbx.bind('<<ComboboxSelected>>', self.material_changed)
+            self.material_cbx.grid(column=1, columnspan=2, row=1, sticky=W,
+                                   padx=(6, 0), pady=2)
             ttk.Label(miscframe, text='Thickness:').grid(
                 column=4, row=1, sticky=E, padx=4, pady=2)
             ttk.Entry(miscframe, textvariable=self.thickness,
@@ -287,6 +288,10 @@ class Application(ttk.Frame):
                   and self.height_ent.get() != ''
                   and self.depth_ent.get() != '')
         return result
+
+    def material_changed(self, e):
+        self.thickness.set(cab.matl_thicknesses[self.material.get()])
+        self.material_cbx.selection_clear()
 
     def diff_btm_changed(self):
         if self.diff_btm_thickness.get() == 'yes':

--- a/cabwiz/gui.py
+++ b/cabwiz/gui.py
@@ -210,8 +210,9 @@ class Application(ttk.Frame):
             ttk.Entry(miscframe, textvariable=self.thickness,
                       width=6).grid(column=5, row=1, sticky=W, pady=2)
             ttk.Label(
-                miscframe, text='Please confirm actual\nmaterial thickness.'
-            ).grid(column=4, columnspan=2, row=2, sticky=N, padx=4, pady=2)
+                miscframe, text='Please check actual material thickness\n'
+                                'and adjust value here accordingly.'
+            ).grid(column=4, columnspan=2, row=2, sticky=N, padx=4, pady=(2,10))
             bottom_thickness_chk = ttk.Checkbutton(
                 miscframe, text='Different Bottom Thickness:',
                 command=self.diff_btm_changed, variable=self.diff_btm_thickness,

--- a/cabwiz/gui.py
+++ b/cabwiz/gui.py
@@ -209,24 +209,27 @@ class Application(ttk.Frame):
                 column=4, row=1, sticky=E, padx=4, pady=2)
             ttk.Entry(miscframe, textvariable=self.thickness,
                       width=6).grid(column=5, row=1, sticky=W, pady=2)
+            ttk.Label(
+                miscframe, text='Please confirm actual\nmaterial thickness.'
+            ).grid(column=4, columnspan=2, row=2, sticky=N, padx=4, pady=2)
             bottom_thickness_chk = ttk.Checkbutton(
                 miscframe, text='Different Bottom Thickness:',
                 command=self.diff_btm_changed, variable=self.diff_btm_thickness,
                 onvalue='yes', offvalue='no').grid(
-                    column=1, columnspan=4, row=2, sticky=E, padx=4, pady=2)
+                    column=1, columnspan=4, row=3, sticky=E, padx=4, pady=2)
             self.bottom_thickness_ent = ttk.Entry(
                 miscframe, textvariable=self.bottom_thickness, width=6
             )
             self.bottom_thickness_ent.state(['disabled'])
-            self.bottom_thickness_ent.grid(column=5, row=2, sticky=W, pady=2)
+            self.bottom_thickness_ent.grid(column=5, row=3, sticky=W, pady=2)
             ttk.Label(miscframe, text='Doors per Cabinet:').grid(
-                column=0, columnspan=2, row=3, sticky=W, padx=(0, 6), pady=2)
+                column=0, columnspan=2, row=4, sticky=W, padx=(0, 6), pady=2)
             ttk.Radiobutton(miscframe, value=1, text='1',
                 variable=self.doors_per_cab).grid(
-                    column=2, row=3, sticky=W, padx=3, pady=2)
+                    column=2, row=4, sticky=W, padx=3, pady=2)
             ttk.Radiobutton(miscframe, value=2, text='2',
                 variable=self.doors_per_cab).grid(
-                    column=3, row=3, sticky=W, padx=3, pady=2)
+                    column=3, row=4, sticky=W, padx=3, pady=2)
 
         def make_buttonframe():
             buttonframe = ttk.Frame(inpframe, padding=(0, 12, 0, 0))


### PR DESCRIPTION
Created module level constants `materials` and `matl_thicknesses` in the cabinet module. `materials` contains a list of allowable materials. `matl_thicknesses` is a dictionary associating each material name with its default thickness in inches as a float.

Changed all parts of the code that use these values, so that they get them from the cabinet module constants. They default to the first material in the list (standard plywood).

Fixes #7.
