### PR TITLE
Fix cutlist header to indicate correctly which ends are finished / unfinished.

### DIFF
--- a/cabwiz/cabinet.py
+++ b/cabwiz/cabinet.py
@@ -32,7 +32,7 @@
 This module implements the...
 
 Given the full width, height, depth, material, material thickness, and
-number of fillers to use, (along with job name)...
+which ends will have fillers, (along with job name)...
 
 ... calculate the number of cabinets needed, each cabinet's width (whether
 integral or not), the space left over to be filled by fillers,
@@ -53,6 +53,7 @@ __version__ = '0.1'
 __author__ = 'Harry H. Toigo II'
 
 import math
+from enum import Enum
 
 # Module constants
 
@@ -73,22 +74,52 @@ materials = ( 'Plywood'
             , 'Steel' )
 
 
-def cabinet_run(fullwidth, height, depth, num_fillers=0, material='Plywood',
-                matl_thickness=0.75, topnailer_depth=4, door_thickness=0.75,
-                doortop_space=0.5, doorside_space_l=0.125,
+class Ends(Enum):
+    """An enumeration of the allowable choices for which end or ends of a
+    cabinet run have fillers.
+
+    It must be one of:
+        neither - no fillers used
+        left - only the left end has a filler
+        right - only the right end has a filler
+        both - both ends have fillers
+
+    This also determines whether or not the end panels must be finished. If an
+    end will have a filler then that end can be left unfinished. On the other
+    hand, an end without a filler must have a finished end panel.
+    """
+    neither = 1
+    left = 2
+    right = 3
+    both = 4
+
+    def __str__(self):
+        return self.name
+
+    @staticmethod
+    def from_string(str):
+        try:
+            return Ends[str]
+        except KeyError:
+            raise ValueError()
+
+
+def cabinet_run(fullwidth, height, depth, fillers=Ends.neither,
+                material='Plywood', matl_thickness=0.75, topnailer_depth=4,
+                door_thickness=0.75, doortop_space=0.5, doorside_space_l=0.125,
                 doorside_space_m=0.125, doorside_space_r=0.125):
     """Construct a (single) :class:`Run <Run>` of cabinets.
 
     :param fullwidth: Total wall width for this run of cabinets.
     :param height: The distance from the toe kick to top of cabinets.
     :param depth: The distance from front to back, including door.
-    :param num_fillers: The number of fillers to use in this run.
+    :param fillers: Which ends of the run will have fillers.
     :param material: The primary building material name.
     :param matl_thickness: Building material thickness.
     :return: :class:`Run <Run>` object
     :rtype: cabinet.Run
     """
-    return Run(fullwidth, height, depth, num_fillers, material, matl_thickness,
+    return Run(fullwidth, height, depth, fillers, material, matl_thickness,
                topnailer_depth, door_thickness, doortop_space, doorside_space_l,
                doorside_space_m, doorside_space_r)
 
@@ -112,16 +143,17 @@ class Run:
     cabinet, as does all code in this module. We may change this later to
     allow single-door cabinets, but that will require a lot of changes.
     """
-    def __init__(self, fullwidth, height, depth, num_fillers=0,
+    def __init__(self, fullwidth, height, depth, fillers=Ends.neither,
                  material='Plywood', matl_thickness=0.75, topnailer_depth=4,
                  door_thickness=0.75, doortop_space=0.5, doorside_space_l=0.125,
                  doorside_space_m=0.125, doorside_space_r=0.125):
         self._fullwidth = fullwidth
         self._height = height
         self._depth = depth
-        self.num_fillers = num_fillers
         self._material = material
         self._matl_thickness = matl_thickness
+        # fillers must be one of: Ends.neither, .left, .right, or .both.
+        self.fillers = fillers
         self.topnailer_depth = topnailer_depth
         self.door_thickness = door_thickness
         # The amount the door is shorter than the cabinet, usually 1/2" or 3/8".
@@ -183,32 +215,41 @@ class Run:
         return self._fullwidth % self.num_cabinets
 
     @property
+    def num_fillers(self):
+        if self.fillers is Ends.neither:
+            result = 0
+        elif self.fillers is Ends.left or self.fillers is Ends.right:
+            result = 1
+        elif self.fillers is Ends.both:
+            result = 2
+        else:
+            raise valueError('fillers is not neither, left, right, or both')
+        return result
+
+    @property
     def filler_width(self):
         """The width of the filler(s) to be used in the run."""
-        if self.num_fillers == 0:
-            width = 0    # or raise exception here?
+        if self.fillers is Ends.neither:
+            width = None
         else:
-            # Should we raise an exception if more than 2 fillers?
             width = self.extra_width / self.num_fillers
         return width
 
     @property
     def filler_height(self):
         """The height of the filler(s) to be used in the run."""
-        if self.num_fillers == 0:
-            height = 0    # or raise exception here?
+        if self.fillers is Ends.neither:
+            height = None
         else:
-            # Should we raise an exception if more than 2 fillers?
             height = self.cabinet_height
         return height
 
     @property
     def filler_thickness(self):
         """The thickness of a filler strip."""
-        if self.num_fillers == 0:
-            thickness = 0    # or raise exception here?
+        if self.fillers is Ends.neither:
+            thickness = None
         else:
-            # Should we raise an exception if more than 2 fillers?
             thickness = self.matl_thickness
         return thickness
 

--- a/cabwiz/cabinet.py
+++ b/cabwiz/cabinet.py
@@ -223,7 +223,7 @@ class Run:
         elif self.fillers is Ends.both:
             result = 2
         else:
-            raise valueError('fillers is not neither, left, right, or both')
+            raise TypeError('fillers is not Ends.neither, .left, .right, or .both')
         return result
 
     @property

--- a/cabwiz/cabwiz.py
+++ b/cabwiz/cabwiz.py
@@ -45,7 +45,7 @@ import argparse
 import textwrap
 
 import gui
-import cabinet as cab
+from cabinet import Ends, Run
 import job
 import cutlist
 from text import wrap
@@ -61,9 +61,9 @@ def start_cli(args):
     """Start the command-line version of the program."""
 
     # Create a cabinet Run object which does all the calculating.
-    cab_run = cab.Run(args.fullwidth, args.height, args.depth,
-                      num_fillers=args.fillers,
-                      matl_thickness=args.thick)
+    cab_run = Run(args.fullwidth, args.height, args.depth,
+                  fillers=args.fillers,
+                  matl_thickness=args.thick)
     # Create a job object that holds the name, a single cabinet run object,
     # and an optional description for the job.
     if args.desc is not None:
@@ -115,11 +115,12 @@ def get_parser():
                         metavar='DESC',
                         type=str)
     parser.add_argument("-f", "--fillers",
-                        help="number of fillers to be used (0, 1, or 2); "
-                             "if unspecified, defaults to 0",
-                        metavar='N',
-                        type=int,
-                        default='0')
+                        # help="fillers to be used (0, 1, or 2); "
+                        #      "if unspecified, defaults to 0",
+                        # metavar='N',
+                        type=Ends.from_string,
+                        choices=list(Ends))
+                        # default=Ends.from_string('neither'))
     parser.add_argument("-m", "--matl",
                         help="primary building material name",
                         type=str)

--- a/cabwiz/cabwiz.py
+++ b/cabwiz/cabwiz.py
@@ -115,12 +115,10 @@ def get_parser():
                         metavar='DESC',
                         type=str)
     parser.add_argument("-f", "--fillers",
-                        # help="fillers to be used (0, 1, or 2); "
-                        #      "if unspecified, defaults to 0",
-                        # metavar='N',
+                        help="ends that will have filler panels",
                         type=Ends.from_string,
-                        choices=list(Ends))
-                        # default=Ends.from_string('neither'))
+                        choices=list(Ends),
+                        default=Ends.from_string('neither'))
     parser.add_argument("-m", "--matl",
                         help="primary building material name",
                         type=str)

--- a/cabwiz/cutlist.py
+++ b/cabwiz/cutlist.py
@@ -169,11 +169,11 @@ def finished_ends(fillers):
     if fillers is Ends.neither:
         result = 'Both end panels finished.'
     elif fillers is Ends.left:
-        result = 'Left end unfinished.\nRight end panel finished.'
+        result = 'Left end unfinished.<br/>Right end panel finished.'
     elif fillers is Ends.right:
-        result = 'Left end panel finished.\nRight end unfinished.'
+        result = 'Left end panel finished.<br/>Right end unfinished.'
     elif fillers is Ends.both:
-        result = 'Both end panels unfinished.'
+        result = 'Both ends unfinished.'
     return result
 
 
@@ -659,7 +659,7 @@ def panels_table(job):
     rowHeights = (130, 130)       # assumes col_ht of 411 pts
                                   # 6.5 * 72 - 45 - 12
     if job.cabs.fillers is Ends.neither:
-        # No fillers used, so do not create a filler panel drawing.
+        # No fillers used; do not create a filler panel drawing.
         data = ( (backpanel_dr, sidepanel_dr, topnailer_dr),
                  (bottompanel_dr, door_dr)
                  )

--- a/cabwiz/cutlist.py
+++ b/cabwiz/cutlist.py
@@ -112,7 +112,7 @@ def pdf_ify(fname):
 
 def makeframes(doc):
     """Return (frameHdr, frameL, frameR), given the document template."""
-    hdr_ht = 60           # pts
+    hdr_ht = 70           # pts
     hdr_spc_after = 12    # pts
     frameHdr = Frame(doc.leftMargin, page_ht - doc.topMargin - hdr_ht,
                      doc.width, hdr_ht, id='hdr'
@@ -197,6 +197,7 @@ def hdr_table(job):
         ('ALIGN', (2,0), (2,0), 'RIGHT'),
         # Job description spans across entire 2nd row.
         ('SPAN', (0,1), (2,1)),
+        ('TOPPADDING', (0,1), (2,1), 9),
         # Nice colors:  cornsilk (0xfff8dc), linen (0xfaf0e6),
         #     lightslategrey (0x778899), 0xc8d8e6.
         ('BACKGROUND', (0,0), (-1,-1), colors.HexColor(0xe0e4e2))

--- a/cabwiz/gui.py
+++ b/cabwiz/gui.py
@@ -44,7 +44,7 @@ from tkinter import ttk
 from tkinter import filedialog
 from functools import reduce
 
-import cabinet as cab
+from cabinet import materials, Ends, Run
 import job
 import cutlist
 from text import wrap
@@ -67,7 +67,7 @@ class Application(ttk.Frame):
         self.fullwidth = StringVar()
         self.height = StringVar()
         self.depth = StringVar()
-        self.num_fillers = IntVar()
+        self.fillers = StringVar()
         self.material = StringVar()
         self.thickness = StringVar()
         self.diff_btm_thickness = StringVar()
@@ -84,7 +84,7 @@ class Application(ttk.Frame):
         self.fullwidth.set('')
         self.height.set('')
         self.depth.set('')
-        self.num_fillers.set(0)
+        self.fillers.set('neither')
         self.material.set('Plywood')
         self.thickness.set('0.75')
         self.diff_btm_thickness.set('no')
@@ -180,22 +180,25 @@ class Application(ttk.Frame):
             miscframe.columnconfigure(4, weight=1)
             miscframe.columnconfigure(5, weight=1)
             miscframe.columnconfigure(6, weight=1)
-            ttk.Label(miscframe, text='Number of fillers:').grid(
+            ttk.Label(miscframe, text='Fillers for which ends?').grid(
                 column=0, columnspan=2, row=0, sticky=W, padx=(0, 2), pady=2)
-            ttk.Radiobutton(miscframe, value=0, text='0',
-                            variable=self.num_fillers).grid(
+            ttk.Radiobutton(miscframe, value='neither', text='Neither',
+                            variable=self.fillers).grid(
                                 column=2, row=0, sticky=W, padx=3, pady=2)
-            ttk.Radiobutton(miscframe, value=1, text='1',
-                            variable=self.num_fillers).grid(
+            ttk.Radiobutton(miscframe, value='left', text='Left',
+                            variable=self.fillers).grid(
                                 column=3, row=0, sticky=W, padx=3, pady=2)
-            ttk.Radiobutton(miscframe, value=2, text='2',
-                            variable=self.num_fillers).grid(
+            ttk.Radiobutton(miscframe, value='right', text='Right',
+                            variable=self.fillers).grid(
                                 column=4, row=0, sticky=W, padx=3, pady=2)
+            ttk.Radiobutton(miscframe, value='both', text='Both',
+                            variable=self.fillers).grid(
+                                column=5, row=0, sticky=W, padx=3, pady=2)
             ttk.Label(miscframe, text='Material:').grid(
                 column=0, row=1, sticky=W, padx=(0, 2), pady=2)
             material_cbx = ttk.Combobox(miscframe, textvariable=self.material,
-                                width=max(map(len, cab.materials)) + 2)
-            material_cbx['values'] = cab.materials
+                                width=max(map(len, materials)) + 2)
+            material_cbx['values'] = materials
             # Prevent direct editing of the value in the combobox:
             material_cbx.state(['readonly'])
             # Call the `selection clear' method when the value changes. It looks
@@ -313,12 +316,12 @@ class Application(ttk.Frame):
         self.output_lbl.grid_configure(pady=(0, 50))
 
     def calculate_job(self):
-        cab_run = cab.Run(float(self.fullwidth.get()),
-                          float(self.height.get()),
-                          float(self.depth.get()),
-                          num_fillers=self.num_fillers.get(),
-                          material=self.material.get(),
-                          matl_thickness=float(self.thickness.get()))
+        cab_run = Run(float(self.fullwidth.get()),
+                      float(self.height.get()),
+                      float(self.depth.get()),
+                      fillers=Ends.from_string(self.fillers.get()),
+                      material=self.material.get(),
+                      matl_thickness=float(self.thickness.get()))
         if self.description.get() != '':
             self.job = job.Job(self.jobname.get(), cab_run,
                                self.description.get())

--- a/cabwiz/job.py
+++ b/cabwiz/job.py
@@ -38,7 +38,7 @@ __version__ = '0.1'
 __author__ = 'Harry H. Toigo II'
 
 
-import cabinet
+from cabinet import Ends
 from dimension_strs import dimstr, dimstr_col
 
 
@@ -70,18 +70,20 @@ class Job:
                    + 'totalling '
                    + dimstr(self.cabs.cabinet_width
                             * self.cabs.num_cabinets) + '"' )
-        if self.cabs.num_fillers == 0:
+        if self.cabs.fillers is Ends.neither:
             result += ( ', with finished end panels on left and right.'
                         ' No filler panels required.\n' )
-        elif self.cabs.num_fillers == 1:
+        elif self.cabs.fillers is Ends.left:
             result += ( ', with a ' + dimstr(self.cabs.filler_width)
-                        + '" filler.\n' )
-        elif self.cabs.num_fillers == 2:
+                        + '" filler on the left.\n' )
+        elif self.cabs.fillers is Ends.right:
+            result += ( ', with a ' + dimstr(self.cabs.filler_width)
+                        + '" filler on the right.\n' )
+        elif self.cabs.fillers is Ends.both:
             result += ( ', with two (2) ' + dimstr(self.cabs.filler_width)
                         + '" fillers.\n' )
         else:
-            # The number of fillers should never be greater than 2.
-            raise ValueError('number of fillers not 0, 1, or 2')
+            raise ValueError('fillers is not neither, left, right, or both')
         return result
 
     @property


### PR DESCRIPTION
The cutlist header now will say one of the following:

    Both ends unfinished.

    Both end panels finished.

    Left end unfinished.
    Right end panel finished.

    Left end panel finished.
    Right end unfinished.

To accomplish this, the way of specifying the fillers was changed from entering the number of fillers (0, 1 or 2) to entering the ends for which fillers are wanted (neither, left, right or both). This has been changed both in the GUI and the command-line interface.

Fixes #11.