### PR TITLE
Separate material and thickness choices for primary and door.

### DIFF
--- a/cabwiz/cabinet.py
+++ b/cabwiz/cabinet.py
@@ -166,9 +166,9 @@ class Run:
     """
     def __init__(self, fullwidth, height, depth, fillers=Ends.neither,
                  prim_material=materials[prim_mat_default],
-                 prim_thickness=matl_thicknesses[self.prim_material],
+                 prim_thickness=matl_thicknesses[materials[prim_mat_default]],
                  door_material=materials[door_mat_default],
-                 door_thickness=matl_thicknesses[self.door_material],
+                 door_thickness=matl_thicknesses[materials[door_mat_default]],
                  topnailer_depth=4,
                  doortop_space=0.5, doorside_space_l=0.125,
                  doorside_space_m=0.125, doorside_space_r=0.125):

--- a/cabwiz/cabinet.py
+++ b/cabwiz/cabinet.py
@@ -65,15 +65,25 @@ max_cabinet_width = 36
 # due to the hinges.
 door_hinge_gap = 0.125
 
-# List of materials, in the order we want them to appear in the selection list.
+# List of materials
+
+# The list order is the order they will appear in the selection list.
 materials = [ 'Standard Plywood'        # default choice if none specified
             , 'Marine-Grade Plywood'
             , 'Melamine'
             ]
 
+# Primary material defaults to Standard Plywood.
+prim_mat_default = 0
+
+# Door material defaults to Melamine.
+door_mat_default = 2
+
 # Dictionary of materials with default thickness for each in inches.
+
 # Note: these thicknesses must still be changeable to something else, as lots do
 # vary in thickness. For example, gray melamine lots are often 0.74" thick.
+
 matl_thicknesses = { 'Standard Plywood': 0.74
                    , 'Marine-Grade Plywood': 0.75
                    , 'Melamine': 0.76
@@ -111,9 +121,11 @@ class Ends(Enum):
 
 
 def cabinet_run(fullwidth, height, depth, fillers=Ends.neither,
-                material=materials[0],
-                matl_thickness=matl_thicknesses[materials[0]],
-                topnailer_depth=4, door_thickness=0.75,
+                prim_material=materials[prim_mat_default],
+                prim_thickness=matl_thicknesses[materials[prim_mat_default]],
+                door_material=materials[door_mat_default],
+                door_thickness=matl_thicknesses[materials[door_mat_default]],
+                topnailer_depth=4,
                 doortop_space=0.5, doorside_space_l=0.125,
                 doorside_space_m=0.125, doorside_space_r=0.125):
     """Construct a (single) :class:`Run <Run>` of cabinets.
@@ -127,8 +139,9 @@ def cabinet_run(fullwidth, height, depth, fillers=Ends.neither,
     :return: :class:`Run <Run>` object
     :rtype: cabinet.Run
     """
-    return Run(fullwidth, height, depth, fillers, material, matl_thickness,
-               topnailer_depth, door_thickness, doortop_space, doorside_space_l,
+    return Run(fullwidth, height, depth, fillers, prim_material, prim_thickness,
+               door_material, door_thickness,
+               topnailer_depth, doortop_space, doorside_space_l,
                doorside_space_m, doorside_space_r)
 
 
@@ -152,20 +165,23 @@ class Run:
     allow single-door cabinets, but that will require a lot of changes.
     """
     def __init__(self, fullwidth, height, depth, fillers=Ends.neither,
-                 material=materials[0],
-                 matl_thickness=matl_thicknesses[materials[0]],
-                 topnailer_depth=4, door_thickness=0.75,
+                 prim_material=materials[prim_mat_default],
+                 prim_thickness=matl_thicknesses[self.prim_material],
+                 door_material=materials[door_mat_default],
+                 door_thickness=matl_thicknesses[self.door_material],
+                 topnailer_depth=4,
                  doortop_space=0.5, doorside_space_l=0.125,
                  doorside_space_m=0.125, doorside_space_r=0.125):
         self._fullwidth = fullwidth
         self._height = height
         self._depth = depth
-        self._material = material
-        self._matl_thickness = matl_thickness
+        self.prim_material = prim_material
+        self.prim_thickness = prim_thickness
+        self.door_material = door_material
+        self.door_thickness = door_thickness
         # fillers must be one of: Ends.neither, .left, .right, or .both.
         self.fillers = fillers
         self.topnailer_depth = topnailer_depth
-        self.door_thickness = door_thickness
         # The amount the door is shorter than the cabinet, usually 1/2" or 3/8".
         self.doortop_space = doortop_space
         # The space to the left, in between, and to the right of the doors.
@@ -173,16 +189,6 @@ class Run:
         self.doorside_space_l = doorside_space_l
         self.doorside_space_m = doorside_space_m
         self.doorside_space_r = doorside_space_r
-
-    @property
-    def material(self):
-        """Primary building material name, as a string."""
-        return self._material
-
-    @property
-    def matl_thickness(self):
-        """Primary building material thickness, as a float."""
-        return self._matl_thickness
 
     @property
     def fullwidth(self):
@@ -260,7 +266,7 @@ class Run:
         if self.fillers is Ends.neither:
             thickness = None
         else:
-            thickness = self.matl_thickness
+            thickness = self.prim_thickness
         return thickness
 
     @property
@@ -287,7 +293,7 @@ class Run:
     @property
     def back_thickness(self):
         """The thickness of a full back panel."""
-        return self.matl_thickness
+        return self.prim_thickness
 
     @property
     def num_bottompanels(self):
@@ -308,7 +314,7 @@ class Run:
     @property
     def bottom_thickness(self):
         """The thickness of a bottom panel."""
-        return self.matl_thickness
+        return self.prim_thickness
 
     @property
     def num_sidepanels(self):
@@ -334,7 +340,7 @@ class Run:
     @property
     def side_thickness(self):
         """The thickness of a side panel."""
-        return self.matl_thickness
+        return self.prim_thickness
 
     @property
     def num_topnailers(self):
@@ -348,12 +354,16 @@ class Run:
 
     @property
     def topnailer_thickness(self):
-        """."""
-        return self.matl_thickness
+        """The thickness of a top nailer panel."""
+        return self.prim_thickness
 
     @property
     def num_doors(self):
-        """The number of doors needed for this run."""
+        """The number of doors needed for this run.
+
+        This function assumes there are exactly 2 doors per cabinet. This may
+        change later.
+        """
         return 2 * self.num_cabinets
 
     @property
@@ -366,7 +376,8 @@ class Run:
     def door_width(self):
         """The width of a single door.
 
-        This function assumes there are exactly 2 doors per cabinet.
+        This function assumes there are exactly 2 doors per cabinet. This may
+        change later.
         """
         width = (self.cabinet_width - self.doorside_space) / 2
         return width

--- a/cabwiz/cabwiz.py
+++ b/cabwiz/cabwiz.py
@@ -45,7 +45,9 @@ import argparse
 import textwrap
 
 import gui
-from cabinet import materials, matl_thicknesses, Ends, Run
+from cabinet import (
+    materials, matl_thicknesses, prim_mat_default, door_mat_default, Ends, Run
+    )
 import job
 import cutlist
 from text import wrap
@@ -63,7 +65,8 @@ def start_cli(args):
     # Create a cabinet Run object which does all the calculating.
     cab_run = Run(args.fullwidth, args.height, args.depth,
                   fillers=args.fillers,
-                  material=args.matl, matl_thickness=args.thick)
+                  prim_material=args.prim_matl, prim_thickness=args.prim_thick,
+                  door_material=args.door_matl, door_thickness=args.door_thick)
     # Create a job object that holds the name, a single cabinet run object,
     # and an optional description for the job.
     if args.desc is not None:
@@ -119,15 +122,26 @@ def get_parser():
                         type=Ends.from_string,
                         choices=list(Ends),
                         default=Ends.from_string('neither'))
-    parser.add_argument("-m", "--matl",
-                        help="primary building material name",
+    parser.add_argument("-pm", "--prim_matl",
+                        help="primary material name",
+                        metavar='MTL',
                         type=str,
-                        default=materials[0])
-    parser.add_argument("-th", "--thick",
-                        help="building material thickness",
+                        default=materials[prim_mat_default])
+    parser.add_argument("-pt", "--prim_thick",
+                        help="primary thickness",
                         metavar='TH',
                         type=float,
-                        default=matl_thicknesses[materials[0]])
+                        default=matl_thicknesses[materials[prim_mat_default]])
+    parser.add_argument("-dm", "--door_matl",
+                        help="door material name",
+                        metavar='MTL',
+                        type=str,
+                        default=materials[door_mat_default])
+    parser.add_argument("-dt", "--door_thick",
+                        help="door thickness",
+                        metavar='TH',
+                        type=float,
+                        default=matl_thicknesses[materials[door_mat_default]])
     parser.add_argument("-c", "--cutlist",
                         help="generate a cutlist & save in FN.pdf",
                         metavar='FN',

--- a/cabwiz/cutlist.py
+++ b/cabwiz/cutlist.py
@@ -224,14 +224,14 @@ def isometric_view(job):
         # horizontal lines------------------------------------------------------
 
         # horizontal bottom inner line
-        (job.cabs.matl_thickness, job.cabs.matl_thickness,
-         (job.cabs.cabinet_width - job.cabs.matl_thickness),
-         job.cabs.matl_thickness),
+        (job.cabs.prim_thickness, job.cabs.prim_thickness,
+         (job.cabs.cabinet_width - job.cabs.prim_thickness),
+         job.cabs.prim_thickness),
 
         # horizontal top inner line - front nailer bottom front edge
-        (job.cabs.matl_thickness, job.cabs.cabinet_height - job.cabs.matl_thickness,
-         job.cabs.cabinet_width - job.cabs.matl_thickness,
-         job.cabs.cabinet_height - job.cabs.matl_thickness),
+        (job.cabs.prim_thickness, job.cabs.cabinet_height - job.cabs.prim_thickness,
+         job.cabs.cabinet_width - job.cabs.prim_thickness,
+         job.cabs.cabinet_height - job.cabs.prim_thickness),
 
         # horizontal top back
         #(iso45, iso45 + job.cabs.cabinet_height,
@@ -240,71 +240,71 @@ def isometric_view(job):
          iso45 + job.cabs.cabinet_width, iso45 + job.cabs.cabinet_height),
 
         # horizontal top back lower
-        #(iso45 - job.cabs.matl_thickness,
-        (iso45 - job.cabs.matl_thickness,
-         job.cabs.cabinet_height + iso45 - job.cabs.matl_thickness,
-         job.cabs.cabinet_width + iso45 - job.cabs.matl_thickness,
-         job.cabs.cabinet_height + iso45 - job.cabs.matl_thickness),
+        #(iso45 - job.cabs.prim_thickness,
+        (iso45 - job.cabs.prim_thickness,
+         job.cabs.cabinet_height + iso45 - job.cabs.prim_thickness,
+         job.cabs.cabinet_width + iso45 - job.cabs.prim_thickness,
+         job.cabs.cabinet_height + iso45 - job.cabs.prim_thickness),
 
         # horizontal inside at bottom back
         (iso45, iso45,
-         job.cabs.cabinet_width - job.cabs.matl_thickness, iso45),
+         job.cabs.cabinet_width - job.cabs.prim_thickness, iso45),
 
         # horizontal front nailer - rear edge
-        (isoNlr45 + job.cabs.matl_thickness, job.cabs.cabinet_height + nlr,
-         job.cabs.cabinet_width - job.cabs.matl_thickness + isoNlr45,
+        (isoNlr45 + job.cabs.prim_thickness, job.cabs.cabinet_height + nlr,
+         job.cabs.cabinet_width - job.cabs.prim_thickness + isoNlr45,
          job.cabs.cabinet_height + nlr),
 
         # horizontal back nailer
         (iso45 - isoNlr45,
-         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.matl_thickness,
-         job.cabs.cabinet_width + iso45 - isoNlr45 - job.cabs.matl_thickness*2,
-         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.matl_thickness),
+         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.prim_thickness,
+         job.cabs.cabinet_width + iso45 - isoNlr45 - job.cabs.prim_thickness*2,
+         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.prim_thickness),
 
         # horizontal back nailer bottom
         (iso45 - isoNlr45,
-         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.matl_thickness*2,
-         job.cabs.cabinet_width + iso45 - isoNlr45 - job.cabs.matl_thickness*3,
-         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.matl_thickness*2),
+         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.prim_thickness*2,
+         job.cabs.cabinet_width + iso45 - isoNlr45 - job.cabs.prim_thickness*3,
+         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.prim_thickness*2),
 
         # vertical lines--------------------------------------------------------
 
         # vertical left inner line
-        (job.cabs.matl_thickness, 0,
-         job.cabs.matl_thickness, job.cabs.cabinet_height),
+        (job.cabs.prim_thickness, 0,
+         job.cabs.prim_thickness, job.cabs.cabinet_height),
 
         # vertical right inner line
-        (job.cabs.cabinet_width - job.cabs.matl_thickness, 0,
-         job.cabs.cabinet_width - job.cabs.matl_thickness, job.cabs.cabinet_height),
+        (job.cabs.cabinet_width - job.cabs.prim_thickness, 0,
+         job.cabs.cabinet_width - job.cabs.prim_thickness, job.cabs.cabinet_height),
 
         # vertical right back
         (iso45 + job.cabs.cabinet_width, iso45,
          iso45 + job.cabs.cabinet_width, job.cabs.cabinet_height + iso45),
 
         # vertical right back inner
-        (job.cabs.cabinet_width + iso45 - job.cabs.matl_thickness,
-         iso45 - job.cabs.matl_thickness,
-         job.cabs.cabinet_width + iso45 - job.cabs.matl_thickness,
-         job.cabs.cabinet_height + iso45 - job.cabs.matl_thickness),
+        (job.cabs.cabinet_width + iso45 - job.cabs.prim_thickness,
+         iso45 - job.cabs.prim_thickness,
+         job.cabs.cabinet_width + iso45 - job.cabs.prim_thickness,
+         job.cabs.cabinet_height + iso45 - job.cabs.prim_thickness),
 
         # vertical back nailer small inner line
         (iso45 - isoNlr45,
-         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.matl_thickness*2,
+         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.prim_thickness*2,
          iso45 - isoNlr45,
-         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.matl_thickness),
+         job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.prim_thickness),
 
         # vertical inside line between nailers
         (iso45, job.cabs.cabinet_height + nlr,
-         iso45, job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.matl_thickness*2),
+         iso45, job.cabs.cabinet_height + iso45 - isoNlr45 - job.cabs.prim_thickness*2),
 
         # vertical inside line at back of left side
         (iso45, iso45,
-         iso45, job.cabs.cabinet_height - job.cabs.matl_thickness),
+         iso45, job.cabs.cabinet_height - job.cabs.prim_thickness),
 
         # angled lines----------------------------------------------------------
 
         # iso bottom left inner angle
-        (job.cabs.matl_thickness, job.cabs.matl_thickness,
+        (job.cabs.prim_thickness, job.cabs.prim_thickness,
          iso45, iso45),
 
         # iso upper left angle
@@ -312,17 +312,17 @@ def isometric_view(job):
          iso45, job.cabs.cabinet_height + iso45),
 
         # iso upper left angle inner
-        (job.cabs.matl_thickness, job.cabs.cabinet_height,
-         iso45,iso45 + job.cabs.cabinet_height - job.cabs.matl_thickness),
+        (job.cabs.prim_thickness, job.cabs.cabinet_height,
+         iso45,iso45 + job.cabs.cabinet_height - job.cabs.prim_thickness),
 
         # iso upper right angle
         (job.cabs.cabinet_width, job.cabs.cabinet_height,
          iso45 + job.cabs.cabinet_width, iso45 + job.cabs.cabinet_height),
 
         # iso upper right angle inner
-        (job.cabs.cabinet_width - job.cabs.matl_thickness, job.cabs.cabinet_height,
-         job.cabs.cabinet_width + iso45 - job.cabs.matl_thickness*2,
-         job.cabs.cabinet_height + iso45 - job.cabs.matl_thickness),
+        (job.cabs.cabinet_width - job.cabs.prim_thickness, job.cabs.cabinet_height,
+         job.cabs.cabinet_width + iso45 - job.cabs.prim_thickness*2,
+         job.cabs.cabinet_height + iso45 - job.cabs.prim_thickness),
 
         # iso lower right angle
         (job.cabs.cabinet_width, 0,
@@ -636,15 +636,15 @@ def panels_table(job):
     """Return a table filled with drawings of the individual panels."""
     backpanel_dr = panel_drawing(
         'Back', job.cabs.back_width, job.cabs.back_height,
-        material=job.cabs.material, thickness=job.cabs.matl_thickness
+        material=job.cabs.prim_material, thickness=job.cabs.back_thickness
         )
     bottompanel_dr = panel_drawing(
         'Bottom', job.cabs.bottom_width, job.cabs.bottom_depth,
-        material=job.cabs.material, thickness=job.cabs.matl_thickness
+        material=job.cabs.prim_material, thickness=job.cabs.bottom_thickness
         )
     sidepanel_dr = panel_drawing(
         'Side', job.cabs.side_depth, job.cabs.side_height,
-        material=job.cabs.material, thickness=job.cabs.matl_thickness
+        material=job.cabs.prim_material, thickness=job.cabs.side_thickness
         )
     # Nailer scale may need to be 1/16 for hdim to fit
     topnailer_dr = panel_drawing(
@@ -653,7 +653,7 @@ def panels_table(job):
     # Door scale may need to be 1/20 for hdim to fit
     door_dr = panel_drawing(
         'Door', job.cabs.door_width, job.cabs.door_height,
-        material=job.cabs.material, thickness=job.cabs.matl_thickness
+        material=job.cabs.door_material, thickness=job.cabs.door_thickness
         )
     # Create table for layout of the panel drawings
     colWidths = ('35%', '35%', '30%')

--- a/cabwiz/gui.py
+++ b/cabwiz/gui.py
@@ -201,11 +201,11 @@ class Application(ttk.Frame):
                             variable=self.fillers).grid(
                                 column=5, row=0, sticky=W, padx=3, pady=2)
 
-            # ttk.Label(miscframe, text='Material choices:').grid(
-            #     column=0, row=1, sticky=W, padx=(0, 2), pady=2)
+            ttk.Label(miscframe, text='Material choices:').grid(
+                column=0, columnspan=2, row=1, sticky=W, padx=(0, 2), pady=2)
 
             ttk.Label(miscframe, text='Primary:').grid(
-                column=0, row=1, sticky=W, padx=(0, 2), pady=2)
+                column=0, row=2, sticky=W, padx=(0, 2), pady=2)
             self.prim_material_cbx = ttk.Combobox(
                 miscframe, textvariable=self.prim_material,
                 width=max(map(len, materials)) + 2
@@ -217,15 +217,15 @@ class Application(ttk.Frame):
             # a bit odd visually without doing that.
             self.prim_material_cbx.bind('<<ComboboxSelected>>',
                                         self.prim_material_changed)
-            self.prim_material_cbx.grid(column=1, columnspan=2, row=1,
+            self.prim_material_cbx.grid(column=1, columnspan=2, row=2,
                                         sticky=W, padx=(6, 0), pady=2)
             ttk.Label(miscframe, text='Thickness:').grid(
-                column=4, row=1, sticky=E, padx=4, pady=2)
+                column=4, row=2, sticky=E, padx=4, pady=2)
             ttk.Entry(miscframe, textvariable=self.prim_thickness,
-                      width=6).grid(column=5, row=1, sticky=W, pady=2)
+                      width=6).grid(column=5, row=2, sticky=W, pady=2)
 
             ttk.Label(miscframe, text='Door:').grid(
-                column=0, row=2, sticky=W, padx=(0, 2), pady=2)
+                column=0, row=3, sticky=W, padx=(0, 2), pady=2)
             self.door_material_cbx = ttk.Combobox(
                 miscframe, textvariable=self.door_material,
                 width=max(map(len, materials)) + 2
@@ -237,30 +237,30 @@ class Application(ttk.Frame):
             # a bit odd visually without doing that.
             self.door_material_cbx.bind('<<ComboboxSelected>>',
                                         self.door_material_changed)
-            self.door_material_cbx.grid(column=1, columnspan=2, row=2,
+            self.door_material_cbx.grid(column=1, columnspan=2, row=3,
                                         sticky=W, padx=(6, 0), pady=2)
             ttk.Label(miscframe, text='Thickness:').grid(
-                column=4, row=2, sticky=E, padx=4, pady=2)
+                column=4, row=3, sticky=E, padx=4, pady=2)
             ttk.Entry(miscframe, textvariable=self.door_thickness,
-                      width=6).grid(column=5, row=2, sticky=W, pady=2)
+                      width=6).grid(column=5, row=3, sticky=W, pady=2)
 
             ttk.Label(
                 miscframe, text='Please check actual material thickness\n'
                                 'and adjust value here accordingly.'
-            ).grid(column=4, columnspan=2, row=3, sticky=N, padx=4, pady=(2,10))
+            ).grid(column=4, columnspan=2, row=4, sticky=N, padx=4, pady=(2,10))
 
             bottom_thickness_chk = ttk.Checkbutton(
                 miscframe, text='Different Bottom Thickness:',
                 command=self.diff_btm_changed, variable=self.diff_btm_thickness,
                 onvalue='yes', offvalue='no').grid(
-                    column=1, columnspan=4, row=4, sticky=E, padx=4, pady=2)
+                    column=1, columnspan=4, row=5, sticky=E, padx=4, pady=2)
             self.bottom_thickness_ent = ttk.Entry(
                 miscframe, textvariable=self.bottom_thickness, width=6
             )
             self.bottom_thickness_ent.state(['disabled'])
-            self.bottom_thickness_ent.grid(column=5, row=4, sticky=W, pady=2)
+            self.bottom_thickness_ent.grid(column=5, row=5, sticky=W, pady=2)
             ttk.Label(miscframe, text='Doors per Cabinet:').grid(
-                column=0, columnspan=2, row=5, sticky=W, padx=(0, 6), pady=(10, 2))
+                column=0, columnspan=2, row=6, sticky=W, padx=(0, 6), pady=(10, 2))
             drs_per_cab_rb1 = ttk.Radiobutton(
                 miscframe, value=1, text='1', variable=self.doors_per_cab
             )
@@ -268,10 +268,10 @@ class Application(ttk.Frame):
             # enabled after major code changes throughout, to allow for upper
             # cabinet banks, variable height/width cabinets, etc.
             drs_per_cab_rb1.state(['disabled'])
-            drs_per_cab_rb1.grid(column=2, row=5, sticky=W, padx=3, pady=(10, 2))
+            drs_per_cab_rb1.grid(column=2, row=6, sticky=W, padx=3, pady=(10, 2))
             ttk.Radiobutton(miscframe, value=2, text='2',
                 variable=self.doors_per_cab).grid(
-                    column=3, row=5, sticky=W, padx=3, pady=(10, 2))
+                    column=3, row=6, sticky=W, padx=3, pady=(10, 2))
 
         def make_buttonframe():
             buttonframe = ttk.Frame(inpframe, padding=(0, 12, 0, 0))

--- a/cabwiz/gui.py
+++ b/cabwiz/gui.py
@@ -367,7 +367,7 @@ class Application(ttk.Frame):
                       float(self.depth.get()),
                       fillers=Ends.from_string(self.fillers.get()),
                       prim_material=self.prim_material.get(),
-                      prim_thickness=float(self.prim_thickness.get())
+                      prim_thickness=float(self.prim_thickness.get()),
                       door_material=self.door_material.get(),
                       door_thickness=float(self.door_thickness.get()))
         if self.description.get() != '':

--- a/cabwiz/job.py
+++ b/cabwiz/job.py
@@ -100,9 +100,12 @@ class Job:
     def materialinfo(self):
         """A list of strings."""
         result = []
-        result.append('Material:  ' + self.cabs.material)
-        result.append('Material thickness:  '
-                      + dimstr(self.cabs.matl_thickness) + '"')
+        result.append('Primary Material:  ' + self.cabs.prim_material)
+        result.append('Primary thickness:  '
+                      + dimstr(self.cabs.prim_thickness) + '"')
+        result.append('Door Material:  ' + self.cabs.door_material)
+        result.append('Door thickness:  '
+                      + dimstr(self.cabs.door_thickness) + '"')
         return result
 
     @property

--- a/cabwiz/job.py
+++ b/cabwiz/job.py
@@ -100,12 +100,14 @@ class Job:
     def materialinfo(self):
         """A list of strings."""
         result = []
-        result.append('Primary Material:  ' + self.cabs.prim_material)
-        result.append('Primary thickness:  '
-                      + dimstr(self.cabs.prim_thickness) + '"')
-        result.append('Door Material:  ' + self.cabs.door_material)
-        result.append('Door thickness:  '
-                      + dimstr(self.cabs.door_thickness) + '"')
+        result.append('Primary Material:  ' + dimstr(self.cabs.prim_thickness)
+                      + '" ' + self.cabs.prim_material)
+        # result.append('Primary thickness:  '
+        #               + dimstr(self.cabs.prim_thickness) + '"')
+        result.append('Door Material:  ' + dimstr(self.cabs.door_thickness)
+                      + '" ' + self.cabs.door_material)
+        # result.append('Door thickness:  '
+        #               + dimstr(self.cabs.door_thickness) + '"')
         return result
 
     @property


### PR DESCRIPTION
Allow the user to choose a primary material and thickness, and separately, a door material and thickness.

This also addresses the issue of the door thickness not changing in response to user input.

Fixes #8 and #1.