### PR TITLE
Refactor text handling in parts of job specification for consistency and simplicity.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ reportlab = "*"
 flake8 = "*"
 pytest = "*"
 coverage = "*"
+pycontracts = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba2f3adaf360f70c328248bf340cf664ab691c538e739511a4d9d3dd6fd58b72"
+            "sha256": "7c3ab52805d65c74552a37b23208770f8bafbe3d2a02d05af2755dba7ca3c4fb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -60,6 +60,13 @@
             "index": "pypi",
             "version": "==5.1"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760",
+                "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"
+            ],
+            "version": "==4.4.2"
+        },
         "entrypoints": {
             "hashes": [
                 "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
@@ -74,6 +81,12 @@
             ],
             "index": "pypi",
             "version": "==3.7.9"
+        },
+        "future": {
+            "hashes": [
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+            ],
+            "version": "==0.18.2"
         },
         "mccabe": {
             "hashes": [
@@ -144,6 +157,13 @@
             ],
             "version": "==2.5.0"
         },
+        "pycontracts": {
+            "hashes": [
+                "sha256:89c0f5e5b9c13468fbb732b6fdb327342da358cef7d4536062596a5f52a9050f"
+            ],
+            "index": "pypi",
+            "version": "==1.8.14"
+        },
         "pyflakes": {
             "hashes": [
                 "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
@@ -160,11 +180,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
+                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==5.4.2"
         },
         "reportlab": {
             "hashes": [

--- a/app/cabinet.py
+++ b/app/cabinet.py
@@ -268,8 +268,7 @@ class Run(object):
         Return the smallest number of cabinets needed, while not exceeding the
         maximum cabinet width.
         """
-        return math.ceil(self.fullwidth / max_cabinet_width)
-
+        return int(math.ceil(self.fullwidth / max_cabinet_width))
     @property
     def cabinet_height(self):
         """The overall cabinet height."""

--- a/app/cabwiz.py
+++ b/app/cabwiz.py
@@ -47,12 +47,12 @@ import sys
 import argparse
 import textwrap
 
-from .cabinet import (
+from app.cabinet import (
     materials, prim_mat_default, door_mat_default, Ends, Run
     )
-from . import gui
-from . import job
-from . import cutlist
+import app.gui as gui
+import app.job as job
+import app.cutlist as cutlist
 
 
 def start_gui():

--- a/app/cabwiz.py
+++ b/app/cabwiz.py
@@ -181,4 +181,4 @@ if __name__ == '__main__':
         start_cli(args)
 
 
-# cabwiz.py ends here
+# cabwiz.py  ends here

--- a/app/cabwiz.py
+++ b/app/cabwiz.py
@@ -47,13 +47,12 @@ import sys
 import argparse
 import textwrap
 
-import gui
-from cabinet import (
+from .cabinet import (
     materials, prim_mat_default, door_mat_default, Ends, Run
     )
-import job
-import cutlist
-from text import wrap
+from . import gui
+from . import job
+from . import cutlist
 
 
 def start_gui():
@@ -83,8 +82,8 @@ def start_cli(args):
 
     # Output the job specification to the terminal, ensuring lines are no
     # longer than 65 chars.
-    for line in wrap(j.specification, 65):
-        print(line)
+    for line in j.specification:
+        print(textwrap.fill(line, width=65))
 
     # If requested, produce and save a cutlist pdf file.
     if args.cutlist is not None:

--- a/app/cutlist.py
+++ b/app/cutlist.py
@@ -46,9 +46,9 @@ from reportlab.graphics.shapes import (
     )
 from reportlab.pdfbase.pdfmetrics import stringWidth
 
-from cabinet import Ends, door_hinge_gap, matl_abbrevs
-from dimension_strs import dimstr, thickness_str
-from text import (
+from .cabinet import Ends, door_hinge_gap, matl_abbrevs
+from .dimension_strs import dimstr, thickness_str
+from .text import (
     normal_style, rt_style, title_style, wallwidth_style, heading_style,
     fixed_style
     )

--- a/app/cutlist.py
+++ b/app/cutlist.py
@@ -47,9 +47,9 @@ from reportlab.graphics.shapes import (
     )
 from reportlab.pdfbase.pdfmetrics import stringWidth
 
-from .cabinet import Ends, door_hinge_gap, matl_abbrevs
-from .dimension_strs import dimstr, thickness_str
-from .text import (
+from app.cabinet import Ends, door_hinge_gap, matl_abbrevs
+from app.dimension_strs import dimstr, thickness_str
+from app.text import (
     normal_style, rt_style, title_style, wallwidth_style, heading_style,
     fixed_style
     )

--- a/app/cutlist.py
+++ b/app/cutlist.py
@@ -150,7 +150,8 @@ def content(job):
     result.append(FrameBreak())
 
     result.append(Paragraph('Overview:', heading_style))
-    result.append(Paragraph(job.summaryln, normal_style))
+    for line in job.summaryln:
+        result.append(Paragraph(line, normal_style))
     result.append(Spacer(1, 10))
     for line in job.cabinfo:
         result.append(Paragraph(line, normal_style))

--- a/app/cutlist.py
+++ b/app/cutlist.py
@@ -31,6 +31,7 @@
 """Cabinet Wiz cutlist generation module.
 """
 
+
 import math
 import re
 
@@ -917,4 +918,4 @@ def matl_thick_strs(material, thickness, rx, ry, rect_width, rect_ht):
     return (thick_str, matl_str)
 
 
-# cutlist.py ends here
+# cutlist.py  ends here

--- a/app/dimension_strs.py
+++ b/app/dimension_strs.py
@@ -31,8 +31,10 @@
 """Cabinet Wiz fractional dimension string module.
 """
 
+
 from fractions import Fraction
 import math
+
 
 debug = False
 
@@ -220,4 +222,4 @@ def upperval_shy_str(i, frac):
     return upperval_str(i, frac) + '-'
 
 
-# dimension_strs.py ends here
+# dimension_strs.py  ends here

--- a/app/gui.py
+++ b/app/gui.py
@@ -39,17 +39,18 @@ This module implements the Cabinet Wiz GUI.
 __version__ = '0.1'
 __author__ = 'Harry H. Toigo II'
 
+
+from functools import reduce
+import textwrap
 from tkinter import *
 from tkinter import ttk
 from tkinter import filedialog
-from functools import reduce
 
-from cabinet import (
+from .cabinet import (
     materials, matl_thicknesses, prim_mat_default, door_mat_default, Ends, Run
     )
-import job
-import cutlist
-from text import wrap
+from . import job
+from . import cutlist
 
 
 def yn_to_bool(str):
@@ -557,7 +558,9 @@ class Application(ttk.Frame):
             self.job = job.Job(self.jobname.get(), cab_run)
         # Display the computed job specification, ensuring output lines are no
         # longer than 65 chars.
-        self.output = '\n'.join(wrap(self.job.specification, 65))
+        self.output = ''
+        for line in self.job.specification:
+            self.output += textwrap.fill(line, width=65) + '\n'
         lines = self.output.count('\n') + 1
         self.output_txt.configure(state='normal')
         self.output_txt.delete('1.0', 'end')

--- a/app/gui.py
+++ b/app/gui.py
@@ -582,4 +582,4 @@ class Application(ttk.Frame):
         pass
 
 
-# gui.py ends here
+# gui.py  ends here

--- a/app/gui.py
+++ b/app/gui.py
@@ -46,11 +46,11 @@ from tkinter import *
 from tkinter import ttk
 from tkinter import filedialog
 
-from .cabinet import (
+from app.cabinet import (
     materials, matl_thicknesses, prim_mat_default, door_mat_default, Ends, Run
     )
-from . import job
-from . import cutlist
+import app.job as job
+import app.cutlist as cutlist
 
 
 def yn_to_bool(str):

--- a/app/job.py
+++ b/app/job.py
@@ -39,8 +39,10 @@ __version__ = '0.1'
 __author__ = 'Harry H. Toigo II'
 
 
-from cabinet import Ends
-from dimension_strs import dimstr, dimstr_col, thickness_str
+from contracts import contract
+
+from .cabinet import Ends
+from .dimension_strs import dimstr, dimstr_col, thickness_str
 
 
 def all_equal(lst):

--- a/app/job.py
+++ b/app/job.py
@@ -61,7 +61,14 @@ class Job(object):
         self.cabs = cab_run
 
     @property
+    @contract
     def header(self):
+        """Header of the job specification.
+
+        Includes job name, job description (if provided), and total wall space.
+
+           :rtype: list[>0](str)
+        """
         result = []
         result.append('Job Name: ' + self.name)
         if self.description != '':
@@ -70,47 +77,58 @@ class Job(object):
         return result
 
     @property
+    @contract
     def summaryln(self):
-        """Return a single string summary of the job."""
-        result = (str(self.cabs.num_cabinets) + ' cabinets measuring '
-                  + dimstr(self.cabs.cabinet_width) + '" '
-                  + 'totalling '
-                  + dimstr(self.cabs.cabinet_width
-                           * self.cabs.num_cabinets) + '"')
+        """A very brief summary of the job.
+
+           :rtype: list[>0](str)
+        """
+        summary = ''
+        summary += (str(self.cabs.num_cabinets) + ' cabinets measuring '
+                    + dimstr(self.cabs.cabinet_width) + '" '
+                    + 'totalling '
+                    + dimstr(self.cabs.cabinet_width
+                             * self.cabs.num_cabinets) + '"')
         if self.cabs.fillers is Ends.neither:
-            result += (', with finished end panels on left and right.'
-                       ' No filler panels required.')
+            summary += (', with finished end panels on left and right.'
+                          ' No filler panels required.')
         elif self.cabs.fillers is Ends.left:
-            result += (', with a ' + dimstr(self.cabs.filler_width)
-                       + '" filler on the left.')
+            summary += (', with a ' + dimstr(self.cabs.filler_width)
+                          + '" filler on the left.')
         elif self.cabs.fillers is Ends.right:
-            result += (', with a ' + dimstr(self.cabs.filler_width)
-                       + '" filler on the right.')
+            summary += (', with a ' + dimstr(self.cabs.filler_width)
+                          + '" filler on the right.')
         elif self.cabs.fillers is Ends.both:
-            result += (', with two (2) ' + dimstr(self.cabs.filler_width)
-                       + '" fillers.')
+            summary += (', with two (2) ' + dimstr(self.cabs.filler_width)
+                          + '" fillers.')
         else:
             raise TypeError('fillers is not Ends.neither, .left, .right,'
                             ' or .both')
         if self.cabs.has_legs:
-            result += (' To be mounted on legs.')
-        result += '\n'
-        return result
+            summary += (' To be mounted on legs.')
+        return [summary]
 
     @property
+    @contract
     def cabinfo(self):
-        """A list of strings."""
+        """Description of the number of cabinets needed and cabinet width.
+
+           :rtype: list[>0](str)
+        """
         result = []
         result.append('Number of cabinets needed:  '
                       + str(self.cabs.num_cabinets))
         result.append('Single cabinet width:  '
                       + dimstr(self.cabs.cabinet_width) + '"')
-        result.append('')
         return result
 
     @property
+    @contract
     def materialinfo(self):
-        """A list of strings."""
+        """Description of the materials needed for the job.
+
+           :rtype: list[>0](str)
+        """
         result = []
         result.append('Primary Material:  '
                       + thickness_str(self.cabs.prim_thickness)
@@ -139,18 +157,28 @@ class Job(object):
         return result
 
     @property
+    @contract
     def overview(self):
+        """Overview of the job specification.
+
+           :rtype: list[>0](str)
+        """
         result = []
-        # result.append('Overview:\n')
-        result.append(self.summaryln)
+        result.extend(self.summaryln)
+        result.append('')
         result.extend(self.cabinfo)
+        result.append('')
         result.extend(self.materialinfo)
         return result
 
     @property
+    @contract
     def partslist(self):
+        """Detailed list of parts needed for the job.
+
+           :rtype: list[>0](str)
+        """
         result = []
-        # result.append('Parts List:\n')
         result.append(
             'Back Panels:     {:2d}  @  {:10s}  x  {:10s}  x  {}'.format(
                 self.cabs.num_backpanels,
@@ -193,8 +221,12 @@ class Job(object):
         return result
 
     @property
+    @contract
     def specification(self):
-        """Return a complete specification of the job as a list of strings."""
+        """Return a complete specification of the job as a list of strings.
+
+           :rtype: list[>0](str)
+        """
         sep = '-' * 65
         result = ([sep] + self.header + [sep]
                   + ['Overview:', ''] + self.overview + [sep]

--- a/app/job.py
+++ b/app/job.py
@@ -41,8 +41,8 @@ __author__ = 'Harry H. Toigo II'
 
 from contracts import contract
 
-from .cabinet import Ends
-from .dimension_strs import dimstr, dimstr_col, thickness_str
+from app.cabinet import Ends
+from app.dimension_strs import dimstr, dimstr_col, thickness_str
 
 
 def all_equal(lst):

--- a/app/job.py
+++ b/app/job.py
@@ -234,4 +234,4 @@ class Job(object):
         return result
 
 
-# job.py ends here
+# job.py  ends here

--- a/app/text.py
+++ b/app/text.py
@@ -40,29 +40,10 @@ __version__ = '0.1'
 __author__ = 'Harry H. Toigo II'
 
 
-import textwrap
-
 from reportlab.rl_config import canvas_basefontname as _baseFontName
 from reportlab.lib.fonts import tt2ps
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_RIGHT, TA_JUSTIFY
-
-
-def wrap(lines, width=70):
-    """Wrap lines longer than `width', returning a new list of lines."""
-    result = []
-    for line in lines:
-        if len(line) <= width:
-            result.append(line)
-        else:
-            # If line ends in a newline, preserve it (textwrap returns a list
-            # of lines without final newlines).
-            ls = textwrap.wrap(line, width)
-            if line[-1] == '\n':
-                # Remember, ls[-1] is a line (a string)
-                ls[-1] = ls[-1] + '\n'
-            result.extend(ls)
-    return result
 
 
 # Fonts

--- a/app/text.py
+++ b/app/text.py
@@ -126,4 +126,4 @@ heading_style = ParagraphStyle(
     spaceAfter=6)
 
 
-# text.py ends here
+# text.py  ends here

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ reportlab
 flake8
 pytest
 coverage
+PyContracts

--- a/tests/test_cabinet.py
+++ b/tests/test_cabinet.py
@@ -2,7 +2,7 @@
 
 
 import pytest
-from ..app import cabinet as C
+import app.cabinet as C
 
 
 @pytest.fixture

--- a/tests/test_cabinet.py
+++ b/tests/test_cabinet.py
@@ -1,14 +1,8 @@
 # test_cabinet.py    -*- coding: utf-8 -*-
 
-import sys
-import os
-
-# Add the root directory of the project to sys.path so that we can find modules
-# in other subtrees (outside of tests dir) for importing.
-sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir))
 
 import pytest
-import app.cabinet as C
+from ..app import cabinet as C
 
 
 @pytest.fixture

--- a/tests/test_cabinet.py
+++ b/tests/test_cabinet.py
@@ -123,4 +123,4 @@ def test_door_height(cabrun):
     assert cabrun.door_height == 28.0
 
 
-# test_cabinet.py ends here
+# test_cabinet.py  ends here

--- a/tests/test_dimension_strs.py
+++ b/tests/test_dimension_strs.py
@@ -50,4 +50,5 @@ class TestSDAlign:
     def test_double_digit_whole(self):
         assert DS.sdalign('17') == '17'
 
-# test_dimension_strs.py ends here
+
+# test_dimension_strs.py  ends here

--- a/tests/test_dimension_strs.py
+++ b/tests/test_dimension_strs.py
@@ -1,7 +1,7 @@
 # test_dimension_strs.py    -*- coding: utf-8 -*-
 
 
-from ..app import dimension_strs as DS
+import app.dimension_strs as DS
 
 
 class TestDimstr:

--- a/tests/test_dimension_strs.py
+++ b/tests/test_dimension_strs.py
@@ -1,13 +1,7 @@
 # test_dimension_strs.py    -*- coding: utf-8 -*-
 
-import sys
-import os
 
-# Add the root directory of the project to sys.path so that we can find modules
-# in other subtrees (outside of tests dir) for importing.
-sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir))
-
-import app.dimension_strs as DS
+from ..app import dimension_strs as DS
 
 
 class TestDimstr:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -47,6 +47,7 @@ def test_job_overview(job):
                             , 'Door Material:  3/4" Melamine']
 
 
+@pytest.mark.skip
 def test_job_partslist(job):
     assert job.partslist == [  'Back Panels:      5  @  31 7/16"    x  27 7/8"     x  3/4"'
                              , 'Bottom Panels:    5  @  29 15/16"   x  24          x  3/4"'
@@ -55,8 +56,10 @@ def test_job_partslist(job):
                              , 'Doors:           10  @  ']
 
 
+@pytest.mark.skip
 def test_job_specification(job):
-    pass
+    assert job.specification == ['-' * 65
+                                 , '']
 
 
 # test_job.py  ends here

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -20,7 +20,9 @@ def test_job_header(job):
 
 
 def test_job_summaryln(job):
-    pass    # assert job.summaryln == ['']
+    assert job.summaryln == ['5 cabinets measuring 31 7/16" totalling 157 1/8"'
+                             ', with finished end panels on left and right.'
+                             ' No filler panels required.']
 
 
 def test_job_cabinfo(job):
@@ -28,4 +30,31 @@ def test_job_cabinfo(job):
                            , 'Single cabinet width:  31 7/16"']
 
 
+def test_job_materialinfo(job):
+    assert job.materialinfo == ['Primary Material:  3/4" Standard Plywood'
+                                , 'Door Material:  3/4" Melamine']
+
+
+def test_job_overview(job):
+    assert job.overview == ['5 cabinets measuring 31 7/16" totalling 157 1/8"'
+                            ', with finished end panels on left and right.'
+                            ' No filler panels required.'
+                            , ''
+                            , 'Number of cabinets needed:  5'
+                            , 'Single cabinet width:  31 7/16"'
+                            , ''
+                            , 'Primary Material:  3/4" Standard Plywood'
+                            , 'Door Material:  3/4" Melamine']
+
+
+def test_job_partslist(job):
+    assert job.partslist == [  'Back Panels:      5  @  31 7/16"    x  27 7/8"     x  3/4"'
+                             , 'Bottom Panels:    5  @  29 15/16"   x  24          x  3/4"'
+                             , 'Side Panels:     10  @              x  27 7/8"     x  3/4"'
+                             , 'Top Nailers:     10  @  '
+                             , 'Doors:           10  @  ']
+
+
+def test_job_specification(job):
+    assert 
 # test_job.py  ends here

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -2,8 +2,8 @@
 
 
 import pytest
-from ..app import cabinet as C
-from ..app import job as J
+import app.cabinet as C
+import app.job as J
 
 
 @pytest.fixture

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -13,10 +13,22 @@ def job():
                  desc='Test various parts of the job module.')
 
 
+@pytest.fixture
+def job_filler_l():
+    return J.Job('Left Filler Job', C.Run(183, 28, 24, fillers=C.Ends.left),
+                 desc='Integer dimensions, filler on left, no legs.')
+
+
 def test_job_header(job):
     assert job.header == ['Job Name: Job 1'
                           , 'Description: Test various parts of the job module.'
                           , 'Total Wall Space: 157.125"']
+
+
+def test_job_filler_l_header(job_filler_l):
+    assert job_filler_l.header == ['Job Name: Left Filler Job'
+                          , 'Description: Integer dimensions, filler on left, no legs.'
+                          , 'Total Wall Space: 183"']
 
 
 def test_job_summaryln(job):
@@ -25,9 +37,19 @@ def test_job_summaryln(job):
                              ' No filler panels required.']
 
 
+def test_job_filler_l_summaryln(job_filler_l):
+    assert job_filler_l.summaryln == ['6 cabinets measuring 30" totalling 180"'
+                             ', with a 3" filler on the left.']
+
+
 def test_job_cabinfo(job):
     assert job.cabinfo == ['Number of cabinets needed:  5'
                            , 'Single cabinet width:  31 7/16"']
+
+
+def test_job_filler_l_cabinfo(job_filler_l):
+    assert job_filler_l.cabinfo == ['Number of cabinets needed:  6'
+                           , 'Single cabinet width:  30"']
 
 
 def test_job_materialinfo(job):
@@ -35,31 +57,112 @@ def test_job_materialinfo(job):
                                 , 'Door Material:  3/4" Melamine']
 
 
+def test_job_filler_l_materialinfo(job_filler_l):
+    assert job_filler_l.materialinfo == [
+        'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine']
+
+
 def test_job_overview(job):
-    assert job.overview == ['5 cabinets measuring 31 7/16" totalling 157 1/8"'
-                            ', with finished end panels on left and right.'
-                            ' No filler panels required.'
-                            , ''
-                            , 'Number of cabinets needed:  5'
-                            , 'Single cabinet width:  31 7/16"'
-                            , ''
-                            , 'Primary Material:  3/4" Standard Plywood'
-                            , 'Door Material:  3/4" Melamine']
+    assert job.overview == [
+        '5 cabinets measuring 31 7/16" totalling 157 1/8"'
+        ', with finished end panels on left and right.'
+        ' No filler panels required.'
+        , ''
+        , 'Number of cabinets needed:  5'
+        , 'Single cabinet width:  31 7/16"'
+        , ''
+        , 'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine']
 
 
-@pytest.mark.skip
+def test_job_filler_l_overview(job_filler_l):
+    assert job_filler_l.overview == [
+        '6 cabinets measuring 30" totalling 180"'
+        ', with a 3" filler on the left.'
+        , ''
+        , 'Number of cabinets needed:  6'
+        , 'Single cabinet width:  30"'
+        , ''
+        , 'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine']
+
+
 def test_job_partslist(job):
-    assert job.partslist == [  'Back Panels:      5  @  31 7/16"    x  27 7/8"     x  3/4"'
-                             , 'Bottom Panels:    5  @  29 15/16"   x  24          x  3/4"'
-                             , 'Side Panels:     10  @              x  27 7/8"     x  3/4"'
-                             , 'Top Nailers:     10  @  '
-                             , 'Doors:           10  @  ']
+    assert job.partslist == [
+        'Back Panels:      5  @  31 7/16"    x  27 7/8"     x  3/4"'
+        , 'Bottom Panels:    5  @  29 15/16"   x  22 3/8"     x  3/4"'
+        , 'Side Panels:     10  @  22 3/8"     x  27 7/8"     x  3/4"'
+        , 'Top Nailers:     10  @  29 15/16"   x   4"         x  3/4"'
+        , 'Doors:           10  @  15 1/2+"    x  27 3/8"     x  3/4"']
 
 
-@pytest.mark.skip
+def test_job_filler_l_partslist(job_filler_l):
+    assert job_filler_l.partslist == [
+        'Back Panels:      6  @  30"         x  28"         x  3/4"'
+        , 'Bottom Panels:    6  @  28 1/2+"    x  22 3/8"     x  3/4"'
+        , 'Side Panels:     12  @  22 3/8"     x  28"         x  3/4"'
+        , 'Top Nailers:     12  @  28 1/2+"    x   4"         x  3/4"'
+        , 'Fillers:          1  @   3"         x  28"         x  3/4"'
+        , 'Doors:           12  @  14 13/16"   x  27 1/2"     x  3/4"']
+
+
 def test_job_specification(job):
-    assert job.specification == ['-' * 65
-                                 , '']
+    assert job.specification == [
+        '-' * 65
+        , 'Job Name: Job 1'
+        , 'Description: Test various parts of the job module.'
+        , 'Total Wall Space: 157.125"'
+        , '-' * 65
+        , 'Overview:'
+        , ''
+        , '5 cabinets measuring 31 7/16" totalling 157 1/8"'
+        ', with finished end panels on left and right.'
+        ' No filler panels required.'
+        , ''
+        , 'Number of cabinets needed:  5'
+        , 'Single cabinet width:  31 7/16"'
+        , ''
+        , 'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine'
+        , '-' * 65
+        , 'Parts List:'
+        , ''
+        , 'Back Panels:      5  @  31 7/16"    x  27 7/8"     x  3/4"'
+        , 'Bottom Panels:    5  @  29 15/16"   x  22 3/8"     x  3/4"'
+        , 'Side Panels:     10  @  22 3/8"     x  27 7/8"     x  3/4"'
+        , 'Top Nailers:     10  @  29 15/16"   x   4"         x  3/4"'
+        , 'Doors:           10  @  15 1/2+"    x  27 3/8"     x  3/4"'
+        , '-' * 65]
+
+
+def test_job_filler_l_specification(job_filler_l):
+    assert job_filler_l.specification == [
+        '-' * 65
+        , 'Job Name: Left Filler Job'
+        , 'Description: Integer dimensions, filler on left, no legs.'
+        , 'Total Wall Space: 183"'
+        , '-' * 65
+        , 'Overview:'
+        , ''
+        , '6 cabinets measuring 30" totalling 180"'
+        ', with a 3" filler on the left.'
+        , ''
+        , 'Number of cabinets needed:  6'
+        , 'Single cabinet width:  30"'
+        , ''
+        , 'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine'
+        , '-' * 65
+        , 'Parts List:'
+        , ''
+        , 'Back Panels:      6  @  30"         x  28"         x  3/4"'
+        , 'Bottom Panels:    6  @  28 1/2+"    x  22 3/8"     x  3/4"'
+        , 'Side Panels:     12  @  22 3/8"     x  28"         x  3/4"'
+        , 'Top Nailers:     12  @  28 1/2+"    x   4"         x  3/4"'
+        , 'Fillers:          1  @   3"         x  28"         x  3/4"'
+        , 'Doors:           12  @  14 13/16"   x  27 1/2"     x  3/4"'
+        , '-' * 65]
 
 
 # test_job.py  ends here

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,0 +1,25 @@
+# test_job.py    -*- coding: utf-8 -*-
+
+
+import pytest
+from ..app import cabinet as C
+from ..app import job as J
+
+
+@pytest.fixture
+def job():
+    # No fillers, no legs
+    return J.Job('Job 1', C.Run(157.125, 27.875, 24),
+                 desc='A job to test various parts of the job module.')
+
+
+def test_job_summaryln(job):
+    pass    # assert job.summaryln == ['']
+
+
+def test_job_cabinfo(job):
+    assert job.cabinfo == ['Number of cabinets needed:  5'
+                           , 'Single cabinet width:  31 7/16"']
+
+
+# test_job.py  ends here

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -56,5 +56,7 @@ def test_job_partslist(job):
 
 
 def test_job_specification(job):
-    assert 
+    pass
+
+
 # test_job.py  ends here

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -10,7 +10,13 @@ import app.job as J
 def job():
     # No fillers, no legs
     return J.Job('Job 1', C.Run(157.125, 27.875, 24),
-                 desc='A job to test various parts of the job module.')
+                 desc='Test various parts of the job module.')
+
+
+def test_job_header(job):
+    assert job.header == ['Job Name: Job 1'
+                          , 'Description: Test various parts of the job module.'
+                          , 'Total Wall Space: 157.125"']
 
 
 def test_job_summaryln(job):


### PR DESCRIPTION
By making sure every part of a job specification returns the same thing (a list of strings with no newlines), we can eliminate the need for our custom wrap() function, and simplify the code that outputs the job specification.

Closes #38.