### PR TITLE
Fix incorrect plural `cabinets' in job summary if only one cabinet.

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -67,20 +67,13 @@
             ],
             "version": "==4.4.2"
         },
-        "entrypoints": {
-            "hashes": [
-                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
-                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
-            ],
-            "version": "==0.3"
-        },
         "flake8": {
             "hashes": [
-                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
-                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
+                "sha256:6c1193b0c3f853ef763969238f6c81e9e63ace9d024518edc020d5f1d6d93195",
+                "sha256:ea6623797bf9a52f4c9577d780da0bb17d65f870213f7b5bcc9fca82540c31d5"
             ],
             "index": "pypi",
-            "version": "==3.7.9"
+            "version": "==3.8.1"
         },
         "future": {
             "hashes": [
@@ -152,10 +145,10 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "version": "==2.5.0"
+            "version": "==2.6.0"
         },
         "pycontracts": {
             "hashes": [
@@ -166,10 +159,10 @@
         },
         "pyflakes": {
             "hashes": [
-                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
-                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "version": "==2.1.1"
+            "version": "==2.2.0"
         },
         "pyparsing": {
             "hashes": [

--- a/app/job.py
+++ b/app/job.py
@@ -83,12 +83,11 @@ class Job(object):
 
            :rtype: list[>0](str)
         """
-        summary = ''
-        summary += (str(self.cabs.num_cabinets) + ' cabinets measuring '
-                    + dimstr(self.cabs.cabinet_width) + '" '
-                    + 'totalling '
-                    + dimstr(self.cabs.cabinet_width
-                             * self.cabs.num_cabinets) + '"')
+        numcabs = self.cabs.num_cabinets
+        cabwidth = self.cabs.cabinet_width
+        summary = (str(numcabs) + (' cabinet' if numcabs == 1 else ' cabinets')
+                   + ' measuring ' + dimstr(cabwidth) + '" ' + 'totalling '
+                   + dimstr(cabwidth * numcabs) + '"')
         if self.cabs.fillers is Ends.neither:
             summary += (', with finished end panels on left and right.'
                           ' No filler panels required.')

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -13,22 +13,10 @@ def job():
                  desc='Test various parts of the job module.')
 
 
-@pytest.fixture
-def job_filler_l():
-    return J.Job('Left Filler Job', C.Run(183, 28, 24, fillers=C.Ends.left),
-                 desc='Integer dimensions, filler on left, no legs.')
-
-
 def test_job_header(job):
     assert job.header == ['Job Name: Job 1'
                           , 'Description: Test various parts of the job module.'
                           , 'Total Wall Space: 157.125"']
-
-
-def test_job_filler_l_header(job_filler_l):
-    assert job_filler_l.header == ['Job Name: Left Filler Job'
-                          , 'Description: Integer dimensions, filler on left, no legs.'
-                          , 'Total Wall Space: 183"']
 
 
 def test_job_summaryln(job):
@@ -37,30 +25,14 @@ def test_job_summaryln(job):
                              ' No filler panels required.']
 
 
-def test_job_filler_l_summaryln(job_filler_l):
-    assert job_filler_l.summaryln == ['6 cabinets measuring 30" totalling 180"'
-                             ', with a 3" filler on the left.']
-
-
 def test_job_cabinfo(job):
     assert job.cabinfo == ['Number of cabinets needed:  5'
                            , 'Single cabinet width:  31 7/16"']
 
 
-def test_job_filler_l_cabinfo(job_filler_l):
-    assert job_filler_l.cabinfo == ['Number of cabinets needed:  6'
-                           , 'Single cabinet width:  30"']
-
-
 def test_job_materialinfo(job):
     assert job.materialinfo == ['Primary Material:  3/4" Standard Plywood'
                                 , 'Door Material:  3/4" Melamine']
-
-
-def test_job_filler_l_materialinfo(job_filler_l):
-    assert job_filler_l.materialinfo == [
-        'Primary Material:  3/4" Standard Plywood'
-        , 'Door Material:  3/4" Melamine']
 
 
 def test_job_overview(job):
@@ -76,18 +48,6 @@ def test_job_overview(job):
         , 'Door Material:  3/4" Melamine']
 
 
-def test_job_filler_l_overview(job_filler_l):
-    assert job_filler_l.overview == [
-        '6 cabinets measuring 30" totalling 180"'
-        ', with a 3" filler on the left.'
-        , ''
-        , 'Number of cabinets needed:  6'
-        , 'Single cabinet width:  30"'
-        , ''
-        , 'Primary Material:  3/4" Standard Plywood'
-        , 'Door Material:  3/4" Melamine']
-
-
 def test_job_partslist(job):
     assert job.partslist == [
         'Back Panels:      5  @  31 7/16"    x  27 7/8"     x  3/4"'
@@ -95,16 +55,6 @@ def test_job_partslist(job):
         , 'Side Panels:     10  @  22 3/8"     x  27 7/8"     x  3/4"'
         , 'Top Nailers:     10  @  29 15/16"   x   4"         x  3/4"'
         , 'Doors:           10  @  15 1/2+"    x  27 3/8"     x  3/4"']
-
-
-def test_job_filler_l_partslist(job_filler_l):
-    assert job_filler_l.partslist == [
-        'Back Panels:      6  @  30"         x  28"         x  3/4"'
-        , 'Bottom Panels:    6  @  28 1/2+"    x  22 3/8"     x  3/4"'
-        , 'Side Panels:     12  @  22 3/8"     x  28"         x  3/4"'
-        , 'Top Nailers:     12  @  28 1/2+"    x   4"         x  3/4"'
-        , 'Fillers:          1  @   3"         x  28"         x  3/4"'
-        , 'Doors:           12  @  14 13/16"   x  27 1/2"     x  3/4"']
 
 
 def test_job_specification(job):
@@ -136,6 +86,56 @@ def test_job_specification(job):
         , '-' * 65]
 
 
+@pytest.fixture
+def job_filler_l():
+    return J.Job('Left Filler Job', C.Run(183, 28, 24, fillers=C.Ends.left),
+                 desc='Integer dimensions, filler on left, no legs.')
+
+
+def test_job_filler_l_header(job_filler_l):
+    assert job_filler_l.header == ['Job Name: Left Filler Job'
+                          , 'Description: Integer dimensions, filler on left, no legs.'
+                          , 'Total Wall Space: 183"']
+
+
+def test_job_filler_l_summaryln(job_filler_l):
+    assert job_filler_l.summaryln == ['6 cabinets measuring 30" totalling 180"'
+                             ', with a 3" filler on the left.']
+
+
+def test_job_filler_l_cabinfo(job_filler_l):
+    assert job_filler_l.cabinfo == ['Number of cabinets needed:  6'
+                           , 'Single cabinet width:  30"']
+
+
+def test_job_filler_l_materialinfo(job_filler_l):
+    assert job_filler_l.materialinfo == [
+        'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine']
+
+
+def test_job_filler_l_overview(job_filler_l):
+    assert job_filler_l.overview == [
+        '6 cabinets measuring 30" totalling 180"'
+        ', with a 3" filler on the left.'
+        , ''
+        , 'Number of cabinets needed:  6'
+        , 'Single cabinet width:  30"'
+        , ''
+        , 'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine']
+
+
+def test_job_filler_l_partslist(job_filler_l):
+    assert job_filler_l.partslist == [
+        'Back Panels:      6  @  30"         x  28"         x  3/4"'
+        , 'Bottom Panels:    6  @  28 1/2+"    x  22 3/8"     x  3/4"'
+        , 'Side Panels:     12  @  22 3/8"     x  28"         x  3/4"'
+        , 'Top Nailers:     12  @  28 1/2+"    x   4"         x  3/4"'
+        , 'Fillers:          1  @   3"         x  28"         x  3/4"'
+        , 'Doors:           12  @  14 13/16"   x  27 1/2"     x  3/4"']
+
+
 def test_job_filler_l_specification(job_filler_l):
     assert job_filler_l.specification == [
         '-' * 65
@@ -162,6 +162,89 @@ def test_job_filler_l_specification(job_filler_l):
         , 'Top Nailers:     12  @  28 1/2+"    x   4"         x  3/4"'
         , 'Fillers:          1  @   3"         x  28"         x  3/4"'
         , 'Doors:           12  @  14 13/16"   x  27 1/2"     x  3/4"'
+        , '-' * 65]
+
+
+@pytest.fixture
+def job_single_cabinet():
+    return J.Job('Single Cabinet Job', C.Run(34.25, 27.75, 28),
+                 desc='Test run with a single cabinet.')
+
+
+def test_job_single_cabinet_header(job_single_cabinet):
+    assert job_single_cabinet.header == [
+        'Job Name: Single Cabinet Job'
+        , 'Description: Test run with a single cabinet.'
+        , 'Total Wall Space: 34.25"']
+
+
+def test_job_single_cabinet_summaryln(job_single_cabinet):
+    assert job_single_cabinet.summaryln == [
+        '1 cabinet measuring 34 1/4" totalling 34 1/4"'
+        ', with finished end panels on left and right.'
+        ' No filler panels required.']
+
+
+def test_job_single_cabinet_cabinfo(job_single_cabinet):
+    assert job_single_cabinet.cabinfo == [
+        'Number of cabinets needed:  1'
+        , 'Single cabinet width:  34 1/4"']
+
+
+def test_job_single_cabinet_materialinfo(job_single_cabinet):
+    assert job_single_cabinet.materialinfo == [
+        'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine']
+
+
+def test_job_single_cabinet_overview(job_single_cabinet):
+    assert job_single_cabinet.overview == [
+        '1 cabinet measuring 34 1/4" totalling 34 1/4"'
+        ', with finished end panels on left and right.'
+        ' No filler panels required.'
+        , ''
+        , 'Number of cabinets needed:  1'
+        , 'Single cabinet width:  34 1/4"'
+        , ''
+        , 'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine']
+
+
+def test_job_single_cabinet_partslist(job_single_cabinet):
+    assert job_single_cabinet.partslist == [
+          'Back Panels:      1  @  34 1/4"     x  27 3/4"     x  3/4"'
+        , 'Bottom Panels:    1  @  32 3/4+"    x  26 3/8"     x  3/4"'
+        , 'Side Panels:      2  @  26 3/8"     x  27 3/4"     x  3/4"'
+        , 'Top Nailers:      2  @  32 3/4+"    x   4"         x  3/4"'
+        , 'Doors:            2  @  16 15/16"   x  27 1/4"     x  3/4"']
+
+
+def test_job_single_cabinet_specification(job_single_cabinet):
+    assert job_single_cabinet.specification == [
+        '-' * 65
+        , 'Job Name: Single Cabinet Job'
+        , 'Description: Test run with a single cabinet.'
+        , 'Total Wall Space: 34.25"'
+        , '-' * 65
+        , 'Overview:'
+        , ''
+        , '1 cabinet measuring 34 1/4" totalling 34 1/4"'
+        ', with finished end panels on left and right.'
+        ' No filler panels required.'
+        , ''
+        , 'Number of cabinets needed:  1'
+        , 'Single cabinet width:  34 1/4"'
+        , ''
+        , 'Primary Material:  3/4" Standard Plywood'
+        , 'Door Material:  3/4" Melamine'
+        , '-' * 65
+        , 'Parts List:'
+        , ''
+        , 'Back Panels:      1  @  34 1/4"     x  27 3/4"     x  3/4"'
+        , 'Bottom Panels:    1  @  32 3/4+"    x  26 3/8"     x  3/4"'
+        , 'Side Panels:      2  @  26 3/8"     x  27 3/4"     x  3/4"'
+        , 'Top Nailers:      2  @  32 3/4+"    x   4"         x  3/4"'
+        , 'Doors:            2  @  16 15/16"   x  27 1/4"     x  3/4"'
         , '-' * 65]
 
 


### PR DESCRIPTION
Fix bug where job summary says: 1 cabinets measuring 34 1/4" totaling 34 1/4".

Closes #36.